### PR TITLE
cargo fmt nightly

### DIFF
--- a/examples/client.rs
+++ b/examples/client.rs
@@ -1,7 +1,8 @@
 use bytes::Bytes;
 use http_body_util::{BodyExt, Empty};
 use hyper_unix_socket::UnixSocketConnector;
-use hyper_util::{client::legacy::Client, rt::TokioExecutor};
+use hyper_util::client::legacy::Client;
+use hyper_util::rt::TokioExecutor;
 use tokio::io::{self, AsyncWriteExt as _};
 
 #[tokio::main(flavor = "current_thread")]

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,11 +1,13 @@
+use std::fmt;
+use std::future::Future;
+use std::marker::PhantomData;
+use std::path::Path;
+use std::pin::Pin;
+use std::task::{self, Context, Poll};
+
 use hyper::Uri;
 use hyper_util::rt::TokioIo;
 use pin_project_lite::pin_project;
-use std::pin::Pin;
-use std::task::Context;
-use std::task::{self, Poll};
-use std::{fmt, marker::PhantomData};
-use std::{future::Future, path::Path};
 use tokio::net::UnixStream;
 use tower_service::Service;
 

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -1,15 +1,11 @@
-use std::fmt;
-use std::io;
 use std::io::IoSlice;
 use std::pin::Pin;
 use std::task::{Context, Poll};
+use std::{fmt, io};
 
 use hyper::rt::{Read, ReadBufCursor, Write};
-
-use hyper_util::{
-    client::legacy::connect::{Connected, Connection},
-    rt::TokioIo,
-};
+use hyper_util::client::legacy::connect::{Connected, Connection};
+use hyper_util::rt::TokioIo;
 use tokio::net::UnixStream;
 
 /// A stream that goes over a Unix socket.


### PR DESCRIPTION
- chore(deps): update rust:1.73.0 docker digest to 4e0bd79
- chore(deps): update rust:1.73.0 docker digest to 25fa7a9
- chore(deps): update returntocorp/semgrep docker tag to v1.47.0
- fix: fix new version
- chore(deps): update mcr.microsoft.com/devcontainers/rust:1-1-bullseye docker digest to 066878f
- chore(deps): update npm to >=10.2.3
- chore(deps): update dependency semantic-release to v22.0.7
- chore(deps): update dependency @semantic-release/release-notes-generator to v12.0.1
- chore(deps): lock file maintenance
- chore(deps): update semantic-release monorepo
- chore(deps): update returntocorp/semgrep docker tag to v1.48.0
- chore(deps): update dependency @semantic-release/github to v9.2.2
- chore(deps): update dependency @semantic-release/github to v9.2.3
- chore(deps): update dependency serialize-error to v11.0.3
- chore(deps): lock file maintenance
- chore(deps): update dependency prettier to v3.1.0
- chore(deps): update actions/github-script action to v7
- chore(deps): update github/codeql-action action to v2.22.6
- chore(deps): update returntocorp/semgrep docker tag to v1.49.0
- chore(deps): update npm to >=10.2.4
- chore(deps): update github/codeql-action action to v2.22.7
- chore(deps): update rust to v1.74.0
- chore(deps): update dependency semantic-release to v22.0.8
- chore(deps): update returntocorp/semgrep docker tag to v1.50.0
- chore(deps): update docker/build-push-action action to v5.1.0
- chore(deps): update actions/github-script action to v7.0.1
- chore(deps): update actions-rs-plus/clippy-check action to v2.2.1
- chore(deps): update actions-rs-plus/clippy-check action to v2.2.2
- chore(deps): roll back actions-rs-plus/clippy-check action to v2.2.0
- chore: use lints
- chore: DENY uninlined format args
- chore: ALLOW uninlined format args
- chore: remove redundant quotes
- chore: bump uninlined format args priority
- chore(deps): lock file maintenance
- chore: add mold, use lints
- chore: restore backtrace always optimize
- chore: fix typo
- chore: pin mold
- chore(deps): update rui314/setup-mold digest to 89146af
- chore(deps): update rust:1.74.0 docker digest to 6de6071
- chore(deps): update node.js to >=20.10.0
- chore(deps): update github/codeql-action action to v2.22.8
- fix: add placeholder for env variable
- chore(deps): lock file maintenance
- chore: disable function-next-line formatting, it looks weird
- chore: rename nextversion to next_version
- chore(deps): update returntocorp/semgrep docker tag to v1.51.0
- chore(deps): update dependency @semantic-release/github to v9.2.4
- chore(deps): update docker/metadata-action action to v5.1.0
- chore(deps): update docker/metadata-action action to v5.2.0
- chore(deps): update rui314/setup-mold digest to 6a9a134
- chore(deps): update alpine docker tag to v3.18.5
- chore(deps): lock file maintenance
- chore(deps): update docker/metadata-action action to v5.3.0
- chore(deps): update dependency semantic-release to v22.0.9
- chore(deps): update returntocorp/semgrep docker tag to v1.52.0
- chore(deps): update dependency semantic-release to v22.0.10
- chore(deps): update npm to >=10.2.5
- chore(deps): update github/codeql-action action to v2.22.9
- chore(deps): update dependency @semantic-release/github to v9.2.5
- chore(deps): update rust docker tag to v1.74.1
- chore(deps): update alpine docker tag to v3.19.0
- chore(deps): update mcr.microsoft.com/devcontainers/rust:1-1-bullseye docker digest to 4ae1575
- chore(deps): update dependency prettier to v3.1.1
- chore(deps): lock file maintenance
- chore(deps): update dependency semantic-release to v22.0.11
- chore(deps): update dependency semantic-release to v22.0.12
- chore(deps): update github/codeql-action action to v2.22.10
- chore(deps): update returntocorp/semgrep docker tag to v1.53.0
- chore(deps): update github/codeql-action action to v2.22.11
- chore(deps): update github/codeql-action action to v3
- chore(deps): update actions/upload-artifact action to v4
- chore(deps): update actions/download-artifact action to v4
- chore(deps): lock file maintenance
- chore(deps): update actions/setup-node action to v4.0.1
- chore(deps): update docker/metadata-action action to v5.4.0
- chore(deps): update rust to v1.74.1
- chore(deps): update actions/download-artifact action to v4.1.0
- chore(deps): update rust:1.74.1 docker digest to 44dd40c
- chore(deps): update rust:1.74.1 docker digest to 0bb7cf3
- chore(deps): update rust:1.74.1 docker digest to fd45a54
- chore(deps): update returntocorp/semgrep docker tag to v1.54.0
- chore(deps): update returntocorp/semgrep docker tag to v1.54.1
- chore(deps): update returntocorp/semgrep docker tag to v1.54.2
- chore(deps): update github/codeql-action action to v3.22.12
- chore(deps): update rui314/setup-mold digest to a06ef65
- chore(deps): update enricomi/publish-unit-test-result-action action to v2.12.0
- chore(deps): update dependency @semantic-release/github to v9.2.6
- chore(deps): update returntocorp/semgrep docker tag to v1.54.3
- chore(deps): lock file maintenance
- chore(deps): update rust to v1.75.0
- chore(deps): lock file maintenance
- chore(deps): update returntocorp/semgrep docker tag to v1.55.0
- chore(deps): update returntocorp/semgrep docker tag to v1.55.1
- chore(deps): update docker/metadata-action action to v5.5.0
- chore(deps): update returntocorp/semgrep docker tag to v1.55.2
- chore(deps): lock file maintenance
- chore(deps): update github/codeql-action action to v3.23.0
- chore(deps): update node.js to >=20.11.0
- chore(deps): update actions/download-artifact action to v4.1.1
- chore(deps): update mcr.microsoft.com/devcontainers/rust:1-1-bullseye docker digest to a0435af
- chore(deps): update npm to >=10.3.0
- chore(deps): update returntocorp/semgrep docker tag to v1.56.0
- chore(deps): update rust:1.75.0 docker digest to 13fda46
- chore(deps): update rust:1.75.0 docker digest to 41c2fff
- chore(deps): update actions/cache action to v3.3.3
- chore(deps): update rust:1.75.0 docker digest to 2f73302
- chore(deps): update rust:1.75.0 docker digest to ea94653
- chore(deps): update actions/upload-artifact action to v4.1.0
- chore(deps): update dependency prettier to v3.2.1
- chore: ensure run and debug from main add the right LOG settings
- chore: console isn't useful, updated casing of levels
- chore(deps): update dependency semantic-release to v23
- chore(deps): update rust:1.75.0 docker digest to 1c5eaf3
- fix: move semantic-release config file as per https://github.com/semantic-release/semantic-release/releases/tag/v23.0.0
- fix: mixed up config name order
- fix: simplified tags
- test: trigger build
- fix: cleanup
- chore(deps): update rust:1.75.0 docker digest to c09b1bb
- chore(deps): update dependency prettier to v3.2.2
- chore: cargo fmt nightly
