### PR TITLE
update from upstream

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,7 @@ jobs:
           fetch-depth: 0
 
       - name: Cache dependencies
-        uses: actions/cache@e12d46a63a90f2fae62d114769bbf2a179198b5c # v3.3.3
+        uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2 # v4
         env:
           CACHE_NAME: cargo-cache-dependencies
         with:
@@ -140,7 +140,7 @@ jobs:
           show-progress: false
 
       - name: Cache dependencies
-        uses: actions/cache@e12d46a63a90f2fae62d114769bbf2a179198b5c # v3.3.3
+        uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2 # v4
         env:
           CACHE_NAME: cargo-cache-dependencies
         with:
@@ -228,7 +228,7 @@ jobs:
           show-progress: false
 
       - name: Cache dependencies
-        uses: actions/cache@e12d46a63a90f2fae62d114769bbf2a179198b5c # v3.3.3
+        uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2 # v4
         env:
           CACHE_NAME: cargo-cache-dependencies
         with:
@@ -270,7 +270,7 @@ jobs:
           show-progress: false
 
       - name: Cache dependencies
-        uses: actions/cache@e12d46a63a90f2fae62d114769bbf2a179198b5c # v3.3.3
+        uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2 # v4
         env:
           CACHE_NAME: cargo-cache-dependencies
         with:
@@ -382,7 +382,7 @@ jobs:
           show-progress: false
 
       - name: Cache dependencies
-        uses: actions/cache@e12d46a63a90f2fae62d114769bbf2a179198b5c # v3.3.3
+        uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2 # v4
         env:
           CACHE_NAME: cargo-cache-dependencies
         with:

--- a/.github/workflows/lint-commits.yml
+++ b/.github/workflows/lint-commits.yml
@@ -24,7 +24,7 @@ jobs:
           fetch-depth: 0
 
       - name: Cache dependencies
-        uses: actions/cache@e12d46a63a90f2fae62d114769bbf2a179198b5c # v3.3.3
+        uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2 # v4
         env:
           CACHE_NAME: cargo-cache-dependencies
         with:

--- a/.prettierrc.yml
+++ b/.prettierrc.yml
@@ -8,7 +8,7 @@ overrides:
       - "**/*.json"
     options:
       tabWidth: 4
-      trailingComma: all
+      trailingComma: none
   - files:
       - "package.json"
       - "package-lock.json"


### PR DESCRIPTION
- chore(deps): lock file maintenance
- chore(deps): update rust:1.75.0 docker digest to b168e2c
- chore(deps): update rust:1.75.0 docker digest to 184a309
- chore: no trailing commas in json
- chore(deps): update dependency prettier to v3.2.3
- chore(deps): update rust:1.75.0 docker digest to 755b46a
- chore(deps): update dependency prettier to v3.2.4
- chore(deps): update github/codeql-action action to v3.23.1
- chore(deps): update actions/cache action to v4
