### PR TITLE
update from upstream

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -358,8 +358,10 @@ jobs:
       - name: Upload coverage results (to Codecov.io)
         uses: codecov/codecov-action@125fc84a9a348dbcf27191600683ec096ec9021c # v4.4.1
         with:
+          disable_search: true
           fail_ci_if_error: true
-          file: reports/lcov.info
+          files: reports/lcov.info
+          plugins: ""
           token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Fail if tests failed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "hyper-unix-socket"
 # don't change this, it's updated before an actual build by update-version.sh
 version = "0.0.0-development"
 edition = "2021"
-rust-version = "1.77.2"
+rust-version = "1.78.0"
 authors = ["Kristof Mattei"]
 description = "Default Unix Socket implementation for use with hyper"
 license = "MIT OR Apache-2.0"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.77.2"
+channel = "1.78.0"
 components = ["cargo", "clippy", "rustfmt"]
 profile = "minimal"


### PR DESCRIPTION
- **chore(deps): update mcr.microsoft.com/devcontainers/rust:1-1-bullseye docker digest to a429f26**
- **chore(deps): update rust:1.77.2 docker digest to 0240e09**
- **chore(deps): update rust:1.77.2 docker digest to 371ae51**
- **chore(deps): update rust:1.77.2 docker digest to 83101f6**
- **chore(deps): update npm to >=10.7.0**
- **chore(deps): update codecov/codecov-action action to v4.3.1**
- **chore(deps): update rust to v1.78.0**
- **chore(deps): update rust:1.78.0 docker digest to 0dd183f**
- **chore(deps): update returntocorp/semgrep docker tag to v1.71.0**
- **chore(deps): update dependency conventional-changelog-conventionalcommits to v8**
- **chore(deps): lock file maintenance**
- **chore(deps): update dependency node to v20.13.0**
- **chore(deps): update mcr.microsoft.com/devcontainers/rust:1-1-bullseye docker digest to e6a3886**
- **chore(deps): update github/codeql-action action to v3.25.4**
- **chore(deps): update returntocorp/semgrep docker tag to v1.72.0**
- **chore(deps): update actions/checkout action to v4.1.5**
- **chore(deps): update dependency node to v20.13.1**
- **chore(deps): update dependency semantic-release to v23.1.1**
- **chore(deps): update rui314/setup-mold digest to eaf386f**
- **chore(deps): update rui314/setup-mold digest to 8de9eea**
- **chore(deps): lock file maintenance**
- **chore(deps): update github/codeql-action action to v3.25.5**
- **chore(deps): update codecov/codecov-action action to v4.4.0**
- **chore(deps): update rust:1.78.0 docker digest to d3d021c**
- **chore(deps): update rust:1.78.0 docker digest to 0b23e41**
- **chore(deps): update rust:1.78.0 docker digest to c296ad0**
- **chore(deps): update rust:1.78.0 docker digest to 5907e96**
- **chore(deps): update dependency @semantic-release/github to v10.0.4**
- **chore(deps): update npm to >=10.8.0**
- **chore(deps): update returntocorp/semgrep docker tag to v1.73.0**
- **chore(deps): update actions/checkout action to v4.1.6**
- **chore(deps): lock file maintenance**
- **chore(deps): update github/codeql-action action to v3.25.6**
- **chore(deps): update codecov/codecov-action action to v4.4.1**
- **chore(deps): update dependency @semantic-release/github to v10.0.5**
- **chore(deps): update alpine docker tag to v3.20.0**
- **chore(deps): update returntocorp/semgrep docker tag to v1.74.0**
- **chore: disable codecov running plugins, disable codecov searching**
