### PR TITLE
update from upstream

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -387,6 +387,14 @@ jobs:
           plugins: ""
           token: ${{ secrets.CODECOV_TOKEN }}
 
+      - name: Upload test results to Codecov
+        uses: codecov/test-results-action@1b5b448b98e58ba90d1a1a1d9fcb72ca2263be46 # v1
+        with:
+          disable_search: true
+          fail_ci_if_error: true
+          files: reports/results.xml
+          token: ${{ secrets.CODECOV_TOKEN }}
+
       - name: Fail if tests failed
         shell: bash
         if: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,9 +194,9 @@ checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "libc"
-version = "0.2.158"
+version = "0.2.159"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
+checksum = "561d97a539a36e26a9a5fad1ea11a3039a67714694aaa379433e580854bc3dc5"
 
 [[package]]
 name = "memchr"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "hyper-unix-socket"
 # don't change this, it's updated before an actual build by update-version.sh
 version = "0.0.0-development"
 edition = "2021"
-rust-version = "1.80.0"
+rust-version = "1.81.0"
 authors = ["Kristof Mattei"]
 description = "Default Unix Socket implementation for use with hyper"
 license = "MIT OR Apache-2.0"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "It's written in Rust!",
   "main": "src/main.rs",
   "scripts": {
-    "prettier": "prettier --write .",
+    "format": "prettier --write .",
     "release": "semantic-release"
   },
   "engines": {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.80.0"
+channel = "1.81.0"
 components = ["cargo", "clippy", "rustfmt"]
 profile = "minimal"


### PR DESCRIPTION
- **chore(deps): update dependency @semantic-release/github to v10.1.5**
- **chore(deps): update returntocorp/semgrep docker tag to v1.85.0**
- **chore(deps): update dependency @semantic-release/github to v10.1.6**
- **chore(deps): update rui314/setup-mold digest to 0bf4f07**
- **chore(deps): update dependency semantic-release to v24.1.0**
- **chore(deps): lock file maintenance**
- **chore(deps): update github/codeql-action action to v3.26.3**
- **chore(deps): update dependency @semantic-release/github to v10.1.7**
- **chore(deps): update mcr.microsoft.com/devcontainers/rust:1-1-bullseye docker digest to 3614a93**
- **chore(deps): update dependency node to v20.17.0**
- **chore(deps): update github/codeql-action action to v3.26.4**
- **chore(deps): update github/codeql-action action to v3.26.5**
- **chore(deps): lock file maintenance**
- **chore(deps): update npm to >=10.8.3**
- **fix: report tests to codecov for tracking**
- **chore: formatting**
- **chore(deps): pin codecov/test-results-action action to 1b5b448**
- **chore(deps): update github/codeql-action action to v3.26.6**
- **chore(deps): update actions/upload-artifact action to v4.4.0**
- **chore(deps): update rust to v1.80.1**
- **chore(deps): lock file maintenance**
- **chore(deps): update dependency @semantic-release/github to v10.3.0**
- **chore(deps): update dependency @semantic-release/github to v10.3.1**
- **chore(deps): update dependency @semantic-release/github to v10.3.2**
- **chore(deps): update enricomi/publish-unit-test-result-action action to v2.17.1**
- **chore(deps): update returntocorp/semgrep docker tag to v1.86.0**
- **chore(deps): update rust:1.80.1 docker digest to d22d893**
- **chore(deps): update dependency @semantic-release/github to v10.3.3**
- **chore(deps): update rust docker tag to v1.81.0**
- **chore(deps): update rust:1.81.0 docker digest to 7fd6c5b**
- **chore(deps): update rust to v1.81.0**
- **chore(deps): update rust:1.81.0 docker digest to fcd390e**
- **chore: remove unneeded .ci**
- **chore(deps): update alpine docker tag to v3.20.3**
- **chore(deps): lock file maintenance**
- **chore(deps): update dependency semantic-release to v24.1.1**
- **chore(deps): update mcr.microsoft.com/devcontainers/rust:1-1-bullseye docker digest to 61c9591**
- **chore(deps): update github/codeql-action action to v3.26.7**
- **chore(deps): update returntocorp/semgrep docker tag to v1.87.0**
- **chore(deps): update dependency @semantic-release/github to v10.3.4**
- **chore(deps): lock file maintenance**
- **chore(deps): update mcr.microsoft.com/devcontainers/rust:1-1-bullseye docker digest to f1d44e2**
- **chore(deps): update returntocorp/semgrep docker tag to v1.88.0**
- **chore(deps): update github/codeql-action action to v3.26.8**
- **chore(deps): update actions/setup-node action to v4.0.4**
- **chore(deps): update returntocorp/semgrep docker tag to v1.89.0**
- **chore(deps): update dependency @semantic-release/github to v10.3.5**
- **chore(deps): lock file maintenance**
- **chore(deps): update mcr.microsoft.com/devcontainers/rust:1-1-bullseye docker digest to 4924241**
- **chore(deps): update github/codeql-action action to v3.26.9**
- **chore(deps): update dependency @semantic-release/github to v11**
