### PR TITLE
update from upstream

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,20 +38,20 @@ non_ascii_idents = { level = "deny", priority = 127 }
 [dependencies]
 bytes = "1"
 hyper = { version = "1.0.0", default-features = false, features = [] }
-hyper-util = { version = "0.1.10", default-features = false, features = [
+hyper-util = { version = "0.1.11", default-features = false, features = [
     "client-legacy",
     "tokio",
 ] }
+pin-project-lite = "0.2.16"
 tokio = { version = "1", default-features = false }
 tower-service = "0.3"
-pin-project-lite = "0.2.16"
 
 [dev-dependencies]
 tokio = { version = "1.33.0", features = ["macros", "io-util"] }
-hyper-util = { version = "0.1.10", default-features = false, features = [
+hyper-util = { version = "0.1.11", default-features = false, features = [
     "http1",
 ] }
-http-body-util = "0.1.2"
+http-body-util = "0.1.3"
 
 [[example]]
 doc-scrape-examples = true


### PR DESCRIPTION
- **chore(deps): update returntocorp/semgrep docker tag to v1.120.1**
- **chore(deps): update rust:1.86.0 docker digest to ff735b1**
- **chore(deps): update rust:1.86.0 docker digest to 13e8910**
- **chore(deps): update rust:1.86.0 docker digest to 173b003**
- **chore(deps): update rust:1.86.0 docker digest to f2b92e8**
- **chore(deps): update rust:1.86.0 docker digest to 640960f**
- **chore(deps): update github/codeql-action action to v3.28.17**
- **chore(deps): bump color eyre**
